### PR TITLE
Support for i.MX 8M chipsets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,21 @@ AC_TYPE_UINT32_T
 AC_FUNC_MMAP
 AC_CHECK_FUNCS([strtoul memset])
 
+# endianness setting
+AC_ARG_WITH(endianness,
+		AS_HELP_STRING(
+			[--with-endianness={big|little}],
+			[define bootcount value endianness]),
+		[endianness=${withval}],
+		[endianness=little]
+	   )
+
+AC_MSG_CHECKING([endianness])
+if test "${endianness}" = "big"; then
+	AC_DEFINE([BIG_ENDIAN], 1, [Define to 1 for big endian])
+fi
+AC_MSG_RESULT([${endianness}])
+
 AC_CONFIG_FILES([
   Makefile
   src/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,6 @@
 AM_CFLAGS               = -std=c99 -pedantic -W -Wall -Wextra -Wno-unused-parameter -Wshadow
 
 sbin_PROGRAMS           = bootcount
-bootcount_SOURCES       = bootcount.c am33xx.c stm32mp1.c i2c_eeprom.c memory.c
+bootcount_SOURCES       = bootcount.c am33xx.c stm32mp1.c i2c_eeprom.c memory.c \
+                          dt.c
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS               = -std=c99 -pedantic -W -Wall -Wextra -Wno-unused-parameter -Wshadow
 
 sbin_PROGRAMS           = bootcount
-bootcount_SOURCES       = bootcount.c am33xx.c stm32mp1.c i2c_eeprom.c
+bootcount_SOURCES       = bootcount.c am33xx.c stm32mp1.c i2c_eeprom.c memory.c
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,5 +2,5 @@ AM_CFLAGS               = -std=c99 -pedantic -W -Wall -Wextra -Wno-unused-parame
 
 sbin_PROGRAMS           = bootcount
 bootcount_SOURCES       = bootcount.c am33xx.c stm32mp1.c i2c_eeprom.c memory.c \
-                          dt.c
+                          dt.c imx8m.c
 

--- a/src/am33xx.c
+++ b/src/am33xx.c
@@ -16,7 +16,7 @@
  * https://github.com/radii/devmem2
  * https://stackoverflow.com/a/12041352/213983
  *
- * This file is part of the uboot-davinci-bootcount (https://github.com/VoltServer/uboot-davinci-bootcount).
+ * This file is part of the uboot-bootcount (https://github.com/VoltServer/uboot-bootcount).
  * Copyright (c) 2018 VoltServer.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/am33xx.c
+++ b/src/am33xx.c
@@ -55,7 +55,7 @@
 #define AM33XX_MEM_OFFSET (RTCSS + SCRATCH2_REG_OFFSET)
 #define AM33XX_MEM_LEN    (KICK1R_REG_OFFSET + REG_SIZE - SCRATCH2_REG_OFFSET)
 
-bool is_ti_am33() {
+bool is_am33() {
     return is_compatible_soc("ti,am33xx");
 }
 

--- a/src/am33xx.c
+++ b/src/am33xx.c
@@ -42,6 +42,16 @@
 #include "./dt.h"
 #include "./am33xx.h"
 
+// See u-boot arch/arm/include/asm/davinci_rtc.h:
+#define RTCSS                0x44E3E000ul
+#define SCRATCH2_REG_OFFSET  0x68ul
+#define REG_SIZE             4ul          // registers are 4 bytes/ 32bit
+
+#define KICK0R_REG_OFFSET 0x6Cul          // see PDF section 20.3.5.23
+#define KICK1R_REG_OFFSET 0x70ul
+#define KICK0_MAGIC       0x83E70B13ul
+#define KICK1_MAGIC       0x95A4F1E0ul
+
 #define AM33XX_MEM_OFFSET (RTCSS + SCRATCH2_REG_OFFSET)
 #define AM33XX_MEM_LEN    (KICK1R_REG_OFFSET + REG_SIZE - SCRATCH2_REG_OFFSET)
 

--- a/src/am33xx.c
+++ b/src/am33xx.c
@@ -39,10 +39,15 @@
 
 #include "./constants.h"
 #include "./memory.h"
+#include "./dt.h"
 #include "./am33xx.h"
 
 #define AM33XX_MEM_OFFSET (RTCSS + SCRATCH2_REG_OFFSET)
 #define AM33XX_MEM_LEN    (KICK1R_REG_OFFSET + REG_SIZE - SCRATCH2_REG_OFFSET)
+
+bool is_ti_am33() {
+    return is_compatible_soc("ti,am33xx");
+}
 
 int am33_read_bootcount(uint16_t* val) {
 

--- a/src/am33xx.h
+++ b/src/am33xx.h
@@ -4,17 +4,6 @@
 
 #define AM33_PLAT_NAME "TI AM335x"
 
-// See u-boot arch/arm/include/asm/davinci_rtc.h:
-#define RTCSS                0x44E3E000ul
-#define SCRATCH2_REG_OFFSET  0x68ul
-#define REG_SIZE             4ul          // registers are 4 bytes/ 32bit
-
-#define KICK0R_REG_OFFSET 0x6Cul          // see PDF section 20.3.5.23
-#define KICK1R_REG_OFFSET 0x70ul
-#define KICK0_MAGIC       0x83E70B13ul
-#define KICK1_MAGIC       0x95A4F1E0ul
-
 bool is_ti_am33();
 int am33_read_bootcount(uint16_t* val);
-
 int am33_write_bootcount(uint16_t val);

--- a/src/am33xx.h
+++ b/src/am33xx.h
@@ -4,6 +4,6 @@
 
 #define AM33_PLAT_NAME "TI AM335x"
 
-bool is_ti_am33();
+bool is_am33();
 int am33_read_bootcount(uint16_t* val);
 int am33_write_bootcount(uint16_t val);

--- a/src/am33xx.h
+++ b/src/am33xx.h
@@ -1,5 +1,7 @@
 # pragma once
 
+#include <stdbool.h>
+
 #define AM33_PLAT_NAME "TI AM335x"
 
 // See u-boot arch/arm/include/asm/davinci_rtc.h:
@@ -12,6 +14,7 @@
 #define KICK0_MAGIC       0x83E70B13ul
 #define KICK1_MAGIC       0x95A4F1E0ul
 
+bool is_ti_am33();
 int am33_read_bootcount(uint16_t* val);
 
 int am33_write_bootcount(uint16_t val);

--- a/src/am33xx.h
+++ b/src/am33xx.h
@@ -1,5 +1,7 @@
 # pragma once
 
+#define AM33_PLAT_NAME "TI AM335x"
+
 // See u-boot arch/arm/include/asm/davinci_rtc.h:
 #define RTCSS                0x44E3E000ul
 #define SCRATCH2_REG_OFFSET  0x68ul

--- a/src/bootcount.c
+++ b/src/bootcount.c
@@ -42,13 +42,6 @@ struct platform {
 
 bool debug = DEBUG;
 
-bool is_ti_am33() {
-    return is_compatible_soc("ti,am33xx");
-}
-
-bool is_stm32mp1() {
-    return is_compatible_soc("st,stm32mp153") || is_compatible_soc("st,stm32mp157");
-}
 static const struct platform platforms[] = {
     {.name = AM33_PLAT_NAME,
      .detect = is_ti_am33,

--- a/src/bootcount.c
+++ b/src/bootcount.c
@@ -30,6 +30,7 @@
 #include "constants.h"
 #include "dt.h"
 #include "am33xx.h"
+#include "imx8m.h"
 #include "stm32mp1.h"
 #include "i2c_eeprom.h"
 
@@ -47,6 +48,11 @@ static const struct platform platforms[] = {
      .detect = is_am33,
      .read_bootcount = am33_read_bootcount,
      .write_bootcount = am33_write_bootcount
+    },
+    {.name = IMX8M_PLAT_NAME,
+     .detect = is_imx8m,
+     .read_bootcount = imx8m_read_bootcount,
+     .write_bootcount = imx8m_write_bootcount
     },
     {.name = STM32MP1_PLAT_NAME,
      .detect = is_stm32mp1,

--- a/src/bootcount.c
+++ b/src/bootcount.c
@@ -44,7 +44,7 @@ bool debug = DEBUG;
 
 static const struct platform platforms[] = {
     {.name = AM33_PLAT_NAME,
-     .detect = is_ti_am33,
+     .detect = is_am33,
      .read_bootcount = am33_read_bootcount,
      .write_bootcount = am33_write_bootcount
     },

--- a/src/bootcount.c
+++ b/src/bootcount.c
@@ -1,7 +1,7 @@
 /**
  * bootcount.c
  *
- * This file is part of the uboot-davinci-bootcount (https://github.com/VoltServer/uboot-davinci-bootcount).
+ * This file is part of the uboot-bootcount (https://github.com/VoltServer/uboot-bootcount).
  * Copyright (c) 2018 VoltServer.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/bootcount.c
+++ b/src/bootcount.c
@@ -47,7 +47,8 @@ bool is_compatible_soc(const char* compat_str) {
     FILE *fd = fopen(DT_COMPATIBLE_NODE, "r");
 
     if (fd == NULL) {
-        fprintf(stderr, "No DT node " DT_COMPATIBLE_NODE "\n");
+        fprintf(stderr, "No DT node " DT_COMPATIBLE_NODE
+                " while searching for \"%s\"\n", compat_str);
         return false;
     }
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #define DEBUG false
 #define BOOTCOUNT_MAGIC   0xB001C041ul    // from u-boot include/common.h
 
@@ -8,3 +10,7 @@
 #define E_DEVICE -2
 #define E_PLATFORM_UNKNOWN -3
 #define E_WRITE_FAILED -4
+
+#define DEBUG_PRINTF(...) if (debug) { fprintf( stderr, "DEBUG: " __VA_ARGS__ ); }
+
+extern bool debug;

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include <config.h>
 #include <stdbool.h>
 
 #define DEBUG false

--- a/src/dt.c
+++ b/src/dt.c
@@ -1,0 +1,70 @@
+/**
+ * Device tree utils
+ *
+ * This file is part of the uboot-bootcount (https://github.com/VoltServer/uboot-bootcount).
+ *
+ * Copyright (c) 2023 Amarula Solutions, Dario Binacchi <dario.binacchi@amarulasolutions.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "constants.h"
+#include "dt.h"
+
+#define DT_COMPATIBLE_NODE "/proc/device-tree/compatible"
+
+/**
+ * Read /proc/device-tree/compatible to detect hardware platform, which
+ * can be used to determine which bootcount strategy to use
+ */
+bool is_compatible_soc(const char* compat_str) {
+    FILE *fd = fopen(DT_COMPATIBLE_NODE, "r");
+
+    if (fd == NULL) {
+        fprintf(stderr, "No DT node " DT_COMPATIBLE_NODE
+                " while searching for \"%s\"\n", compat_str);
+        return false;
+    }
+
+    char compatible[100];
+    bool is_match = false;
+    int bytes_read = 0;
+
+    while (feof(fd) == 0 && ferror(fd) == 0 && ! is_match) {
+        // Note: if the 'compatible' node specifies multiple strings, they will be
+        // null-delineated. Therefore fread() can be used to read the whole file however
+        // string functions like like strstr() will only consider data up to the first null byte.
+        // We need to continue comparing strings up to bytes_read
+
+        if ( (bytes_read = fread(compatible, 1, sizeof(compatible)-1, fd)) > 0 ) {
+            compatible[bytes_read] = 0; // null-terminate the full string
+            char *ptr = compatible;
+            while( ptr < compatible+bytes_read ) {
+                DEBUG_PRINTF("Read from " DT_COMPATIBLE_NODE ": %s\n", ptr);
+                if(strstr(ptr, compat_str) != NULL) {
+                    DEBUG_PRINTF("   Found! %s\n", compat_str);
+                    is_match = true;
+                    break;
+                }
+                ptr += strlen(ptr) + 1;
+            }
+        }
+    }
+
+    fclose(fd);
+    return is_match;
+}

--- a/src/dt.h
+++ b/src/dt.h
@@ -1,0 +1,25 @@
+/**
+ * Device tree utils
+ *
+ * This file is part of the uboot-bootcount (https://github.com/VoltServer/uboot-bootcount).
+ *
+ * Copyright (c) 2023 Amarula Solutions, Dario Binacchi <dario.binacchi@amarulasolutions.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+bool is_compatible_soc(const char* compat);

--- a/src/i2c_eeprom.c
+++ b/src/i2c_eeprom.c
@@ -33,6 +33,12 @@
 #include "constants.h"
 #include "i2c_eeprom.h"
 
+#define DEFAULT_OFFSET 0x100
+
+// EEPROM does not use the same bootcount magic:
+// https://github.com/u-boot/u-boot/blob/master/drivers/bootcount/i2c-eeprom.c#L13
+#define EEPROM_MAGIC 0xbc
+
 int open_eeprom(uint8_t bus, uint8_t addr, off_t offset);
 
 int eeprom_read_bootcount2(uint16_t *val, uint8_t bus, uint8_t addr, off_t offset);

--- a/src/i2c_eeprom.c
+++ b/src/i2c_eeprom.c
@@ -85,7 +85,7 @@ int eeprom_write_bootcount2(uint16_t val, uint8_t bus, uint8_t addr, off_t offse
         return E_DEVICE;
     }
     if ( (size_t)written < sizeof(data) ) {
-        fprintf(stderr, "Incomplete write: %d bytes!\n", written);
+        fprintf(stderr, "Incomplete write: %zd bytes!\n", written);
     }
     close(fd);
 

--- a/src/i2c_eeprom.h
+++ b/src/i2c_eeprom.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define EEPROM_NAME "I2C EEPROM"
+
 #define DEFAULT_I2C_BUS 2
 #define DEFFAULT_I2C_ADDR 50
 #define DEFAULT_OFFSET 0x100

--- a/src/i2c_eeprom.h
+++ b/src/i2c_eeprom.h
@@ -4,16 +4,9 @@
 
 #define DEFAULT_I2C_BUS 2
 #define DEFFAULT_I2C_ADDR 50
-#define DEFAULT_OFFSET 0x100
-
-// EEPROM does not use the same bootcount magic:
-// https://github.com/u-boot/u-boot/blob/master/drivers/bootcount/i2c-eeprom.c#L13
-#define EEPROM_MAGIC 0xbc
 
 #define EEPROM_PATH "/sys/bus/i2c/devices/%d-%04d/eeprom"
 
 int eeprom_read_bootcount(uint16_t *val);
-
 int eeprom_write_bootcount(uint16_t val);
-
 bool eeprom_exists(void);

--- a/src/imx8m.c
+++ b/src/imx8m.c
@@ -1,0 +1,86 @@
+/**
+ * Access and reset u-boot's "bootcount" counter for IMX8M platform
+ *
+ * This file is part of the uboot-bootcount (https://github.com/VoltServer/uboot-bootcount).
+ *
+ * See:
+ * - IMX8MPRM.pdf: i.MX 8M Plus Applications Processor Reference Manual
+ * - IMX8MNRM.pdf: i.MX 8M Nano Applications Processor Reference Manual
+ * - IMX8MDQLQRM.pdf: i.MX 8M Dual/8M QuadLite/8M Quad Applications Processors Reference Manual
+ *
+ * Section 6.4 Secure Non-Volatile Storage (SNVS)
+ * Section 6.4.5.1 SNVS Memory map
+ * Section 6.4.5.16 SNVS_LP General Purpose Registers 0 .. 3 (LPGPR0_alias -LPGPR3_alias)
+ *
+ * Copyright (c) 2023 Amarula Solutions, Dario Binacchi <dario.binacchi@amarulasolutions.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "constants.h"
+#include "dt.h"
+#include "memory.h"
+
+#define SNVS_BASE_ADDR 0x30370000
+#define SNVS_LPGPR0_ALIAS_REG_OFFSET 0x90
+#define SNVS_LPGPR0_ALIAS_REG_SIZE 4
+
+#define IMX8M_MEM_OFFSET (SNVS_BASE_ADDR + SNVS_LPGPR0_ALIAS_REG_OFFSET)
+#define IMX8M_MEM_LEN (SNVS_LPGPR0_ALIAS_REG_SIZE)
+
+bool is_imx8m() {
+    return is_compatible_soc("fsl,imx8mm") || is_compatible_soc("fsl,imx8mn") ||
+           is_compatible_soc("fsl,imx8mp") || is_compatible_soc("fsl,imx8mq");
+}
+
+int imx8m_read_bootcount(uint16_t* val) {
+
+    uint32_t *gprg0;
+
+    gprg0 = memory_open(IMX8M_MEM_OFFSET, IMX8M_MEM_LEN);
+    if (gprg0 == (void *)E_DEVICE)
+        return E_DEVICE;
+
+    /* low two bytes are the value, high two bytes are magic */
+    if ((*gprg0 & 0xffff0000) != (BOOTCOUNT_MAGIC & 0xffff0000))
+        return E_BADMAGIC;
+
+    *val = (uint16_t)(*gprg0 & 0x0000ffff);
+    return 0;
+}
+
+int imx8m_write_bootcount(uint16_t val) {
+    // NOTE: These must be volatile.
+    // See https://github.com/brgl/busybox/blob/master/miscutils/devmem.c
+    volatile uint32_t *gprg0;
+    uint16_t read_val = 0;
+
+    gprg0 = (volatile uint32_t *)memory_open(IMX8M_MEM_OFFSET, IMX8M_MEM_LEN);
+    if (gprg0 == (void *)E_DEVICE )
+        return E_DEVICE;
+
+    *gprg0 = (BOOTCOUNT_MAGIC & 0xffff0000) | (val & 0xffff);
+
+    /* read back to verify */
+    imx8m_read_bootcount(&read_val);
+    if (read_val != val)
+        return E_WRITE_FAILED;
+
+    return 0;
+}

--- a/src/imx8m.h
+++ b/src/imx8m.h
@@ -1,0 +1,28 @@
+/**
+ * Access and reset u-boot's "bootcount" counter for IMX8M platform
+ *
+ * This file is part of the uboot-bootcount (https://github.com/VoltServer/uboot-bootcount).
+ *
+ * Copyright (c) 2022 Amarula Solutions, Dario Binacchi <dario.binacchi@amarulasolutions.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+# pragma once
+
+#define IMX8M_PLAT_NAME "IMX8M"
+
+bool is_imx8m();
+int imx8m_read_bootcount(uint16_t* val);
+int imx8m_write_bootcount(uint16_t val);
+

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,0 +1,60 @@
+/**
+ * Memory access
+ *
+ * This file is part of the uboot-bootcount (https://github.com/VoltServer/uboot-bootcount).
+ *
+ * Copyright (c) 2023 Amarula Solutions, Dario Binacchi <dario.binacchi@amarulasolutions.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "constants.h"
+#include "memory.h"
+
+void *memory_open(off_t offset, size_t len) {
+    size_t pagesize;
+    off_t page_base, page_offset;
+    int fd;
+    uint8_t *mem;
+
+    /*
+     * Truncate offset to a multiple of the page size, or mmap will fail.
+     * see: https://stackoverflow.com/a/12041352/213983
+     */
+    pagesize = sysconf(_SC_PAGE_SIZE);
+    page_base = (offset / pagesize) * pagesize;
+    page_offset = offset - page_base;
+
+    fd = open("/dev/mem", O_SYNC | O_RDWR);
+    if (fd < 0) {
+        perror("open_memory(): open(\"/dev/mem\") failed");
+        return (void *)E_DEVICE;
+    }
+
+    mem = mmap(NULL, page_offset + len, PROT_READ | PROT_WRITE, MAP_SHARED,
+	       fd, page_base);
+    close(fd);
+
+    if (mem == MAP_FAILED) {
+        perror("memory_open(): mmap() failed");
+        return (void *)E_DEVICE;
+    }
+
+    return (mem + page_offset);
+}

--- a/src/memory.c
+++ b/src/memory.c
@@ -27,6 +27,12 @@
 #include "constants.h"
 #include "memory.h"
 
+#define uswap_32(x) \
+	((((x) & 0xff000000) >> 24) | \
+	 (((x) & 0x00ff0000) >>  8) | \
+	 (((x) & 0x0000ff00) <<  8) | \
+	 (((x) & 0x000000ff) << 24))
+
 void *memory_open(off_t offset, size_t len) {
     size_t pagesize;
     off_t page_base, page_offset;
@@ -58,3 +64,29 @@ void *memory_open(off_t offset, size_t len) {
 
     return (mem + page_offset);
 }
+
+#ifdef BIG_ENDIAN
+uint32_t memory_read(volatile uint32_t *addr)
+{
+	volatile uint32_t val = *addr;
+
+	return uswap_32(val);
+}
+
+void memory_write(volatile uint32_t *addr, uint32_t data)
+{
+	*addr = uswap_32(data);
+}
+#else
+uint32_t memory_read(volatile uint32_t *addr)
+{
+	volatile uint32_t val = *addr;
+
+	return val;
+}
+
+void memory_write(volatile uint32_t *addr, uint32_t data)
+{
+	*addr = data;
+}
+#endif

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,0 +1,25 @@
+/**
+ * Memory access
+ *
+ * This file is part of the uboot-bootcount (https://github.com/VoltServer/uboot-bootcount).
+ *
+ * Copyright (c) 2023 Amarula Solutions, Dario Binacchi <dario.binacchi@amarulasolutions.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+# pragma once
+
+#include <sys/types.h>
+
+void *memory_open(off_t offset, size_t len);

--- a/src/memory.h
+++ b/src/memory.h
@@ -23,3 +23,5 @@
 #include <sys/types.h>
 
 void *memory_open(off_t offset, size_t len);
+uint32_t memory_read(volatile uint32_t *addr);
+void memory_write(volatile uint32_t *addr, uint32_t data);

--- a/src/stm32mp1.c
+++ b/src/stm32mp1.c
@@ -28,6 +28,11 @@
 #include "./dt.h"
 #include "./stm32mp1.h"
 
+// See https://wiki.st.com/stm32mpu/wiki/STM32MP15_backup_registers#BOOT_COUNTER
+#define TAMP_BKP0R 0x5C00A100ul
+#define TAMP_BKP21R_OFFSET 0x54ul
+#define REG_SIZE             4ul          // registers are 4 bytes/ 32bit
+
 #define STM32MP1_MEM_OFFSET (TAMP_BKP0R + TAMP_BKP21R_OFFSET)
 #define STM32MP1_MEM_LEN (REG_SIZE)
 

--- a/src/stm32mp1.c
+++ b/src/stm32mp1.c
@@ -2,7 +2,7 @@
  * Access and reset u-boot's "bootcount" counter for the STM32MP1 platform
  * which is stored in the TAMP_BKP21R.
  *
- * This file is part of the uboot-davinci-bootcount (https://github.com/VoltServer/uboot-davinci-bootcount).
+ * This file is part of the uboot-bootcount (https://github.com/VoltServer/uboot-bootcount).
  * Copyright (c) 2018 VoltServer.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/stm32mp1.c
+++ b/src/stm32mp1.c
@@ -25,10 +25,15 @@
 
 #include "./constants.h"
 #include "./memory.h"
+#include "./dt.h"
 #include "./stm32mp1.h"
 
 #define STM32MP1_MEM_OFFSET (TAMP_BKP0R + TAMP_BKP21R_OFFSET)
 #define STM32MP1_MEM_LEN (REG_SIZE)
+
+bool is_stm32mp1() {
+    return is_compatible_soc("st,stm32mp153") || is_compatible_soc("st,stm32mp157");
+}
 
 int stm32mp1_read_bootcount(uint16_t* val) {
 

--- a/src/stm32mp1.h
+++ b/src/stm32mp1.h
@@ -1,11 +1,15 @@
 # pragma once
 
+#include <stdbool.h>
+
 #define STM32MP1_PLAT_NAME "STM32MP1"
 
 // See https://wiki.st.com/stm32mpu/wiki/STM32MP15_backup_registers#BOOT_COUNTER
 #define TAMP_BKP0R 0x5C00A100ul
 #define TAMP_BKP21R_OFFSET 0x54ul
 #define REG_SIZE             4ul          // registers are 4 bytes/ 32bit
+
+bool is_stm32mp1();
 
 int stm32mp1_read_bootcount(uint16_t* val);
 

--- a/src/stm32mp1.h
+++ b/src/stm32mp1.h
@@ -4,13 +4,6 @@
 
 #define STM32MP1_PLAT_NAME "STM32MP1"
 
-// See https://wiki.st.com/stm32mpu/wiki/STM32MP15_backup_registers#BOOT_COUNTER
-#define TAMP_BKP0R 0x5C00A100ul
-#define TAMP_BKP21R_OFFSET 0x54ul
-#define REG_SIZE             4ul          // registers are 4 bytes/ 32bit
-
 bool is_stm32mp1();
-
 int stm32mp1_read_bootcount(uint16_t* val);
-
 int stm32mp1_write_bootcount(uint16_t val);

--- a/src/stm32mp1.h
+++ b/src/stm32mp1.h
@@ -1,5 +1,7 @@
 # pragma once
 
+#define STM32MP1_PLAT_NAME "STM32MP1"
+
 // See https://wiki.st.com/stm32mpu/wiki/STM32MP15_backup_registers#BOOT_COUNTER
 #define TAMP_BKP0R 0x5C00A100ul
 #define TAMP_BKP21R_OFFSET 0x54ul


### PR DESCRIPTION
The series adds bootcount support for the i.MX8M platform (last patch). 
It also includes rework patches to facilitate the addition of a new platform and two patches to handle the 
endianness of the bootcount value. 
I have tested the series on the STM32MP1, am33xx (BeagleBone), and i.MX8M platforms.