### PR TITLE
Support IMX93 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ Compatible platforms:
  * `fsl,imx8mp`
  * `fsl,imx8mq`
 
+### NXP iMX93
+
+NXP iMX93 uses the `BBNSM GPR0` register.
+
+Compatible platforms:
+ * `fsl,imx93`
+
 ### I2C EEPROM
 
 Chipsets without a dedicated register can use I2C EEPROM.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,5 +2,5 @@ AM_CFLAGS               = -std=c99 -pedantic -W -Wall -Wextra -Wno-unused-parame
 
 sbin_PROGRAMS           = bootcount
 bootcount_SOURCES       = bootcount.c am33xx.c stm32mp1.c i2c_eeprom.c memory.c \
-                          dt.c imx8m.c
+                          dt.c imx8m.c imx93.c
 

--- a/src/bootcount.c
+++ b/src/bootcount.c
@@ -31,6 +31,7 @@
 #include "dt.h"
 #include "am33xx.h"
 #include "imx8m.h"
+#include "imx93.h"
 #include "stm32mp1.h"
 #include "i2c_eeprom.h"
 
@@ -53,6 +54,11 @@ static const struct platform platforms[] = {
      .detect = is_imx8m,
      .read_bootcount = imx8m_read_bootcount,
      .write_bootcount = imx8m_write_bootcount
+    },
+    {.name = IMX93_PLAT_NAME,
+     .detect = is_imx93,
+     .read_bootcount = imx93_read_bootcount,
+     .write_bootcount = imx93_write_bootcount
     },
     {.name = STM32MP1_PLAT_NAME,
      .detect = is_stm32mp1,
@@ -184,6 +190,8 @@ int main(int argc, char *argv[]) {
                     "Read or set the u-boot 'bootcount'.  Presently supports the following:\n"
                     "  * RTC SCRATCH2 register on TI AM33xx devices\n"
                     "  * TAMP_BKP21R register on STM32MP1 devices\n"
+                    "  * SNVS_LPGPR0 register on IMX8M devices\n"
+                    "  * BBNSM_GPR0 register on IMX93 devices\n"
                     "  * generic DM I2C EEPROM via /sys/bus/i2c/devices/\n"
                     "If invoked without any arguments, this prints the current 'bootcount'\n"
                     "value to stdout.\n\n"

--- a/src/imx93.c
+++ b/src/imx93.c
@@ -1,0 +1,83 @@
+/**
+ * Access and reset u-boot's "bootcount" counter for IMX93 platform
+ *
+ * This file is part of the uboot-bootcount (https://github.com/VoltServer/uboot-bootcount).
+ *
+ * See:
+ * - IMX93RM.pdf: i.MX 93 Applications Processor Reference Manual
+ *
+ * Chapter 33 Battery-Backed Non-Secure Module (BBNSM)
+ * Section 33.6.1.1 BBNSM memory map
+ * Section 33.6.1.11 General Purpose Register Word a (GPR0 - GPR7)
+ *
+ * Copyright (c) 2024 ELCO Elettronica Automation s.r.l., Stefano Costa <s.costa@elcoelettronica.it>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "constants.h"
+#include "dt.h"
+#include "memory.h"
+
+#define BBNSM_BASE_ADDR 0x44440000
+#define BBNSM_GPR0_ALIAS_REG_OFFSET 0x300
+#define BBNSM_GPR0_ALIAS_REG_SIZE 4
+
+#define IMX93_MEM_OFFSET (BBNSM_BASE_ADDR + BBNSM_GPR0_ALIAS_REG_OFFSET)
+#define IMX93_MEM_LEN (BBNSM_GPR0_ALIAS_REG_SIZE)
+
+bool is_imx93() {
+    return is_compatible_soc("fsl,imx93");
+}
+
+int imx93_read_bootcount(uint16_t* val) {
+
+    uint32_t *gpr0;
+
+    gpr0 = memory_open(IMX93_MEM_OFFSET, IMX93_MEM_LEN);
+    if (gpr0 == (void *)E_DEVICE)
+        return E_DEVICE;
+
+    /* low two bytes are the value, high two bytes are magic */
+    if ((*gpr0 & 0xffff0000) != (BOOTCOUNT_MAGIC & 0xffff0000))
+        return E_BADMAGIC;
+
+    *val = (uint16_t)(*gpr0 & 0x0000ffff);
+    return 0;
+}
+
+int imx93_write_bootcount(uint16_t val) {
+    // NOTE: These must be volatile.
+    // See https://github.com/brgl/busybox/blob/master/miscutils/devmem.c
+    volatile uint32_t *gpr0;
+    uint16_t read_val = 0;
+
+    gpr0 = (volatile uint32_t *)memory_open(IMX93_MEM_OFFSET, IMX93_MEM_LEN);
+    if (gpr0 == (void *)E_DEVICE )
+        return E_DEVICE;
+
+    *gpr0 = (BOOTCOUNT_MAGIC & 0xffff0000) | (val & 0xffff);
+
+    /* read back to verify */
+    imx93_read_bootcount(&read_val);
+    if (read_val != val)
+        return E_WRITE_FAILED;
+
+    return 0;
+}

--- a/src/imx93.h
+++ b/src/imx93.h
@@ -1,0 +1,28 @@
+/**
+ * Access and reset u-boot's "bootcount" counter for IMX93 platform
+ *
+ * This file is part of the uboot-bootcount (https://github.com/VoltServer/uboot-bootcount).
+ *
+ * Copyright (c) 2024 ELCO Elettronica Automation s.r.l., Stefano Costa <s.costa@elcoelettronica.it>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+# pragma once
+
+#define IMX93_PLAT_NAME "IMX93"
+
+bool is_imx93();
+int imx93_read_bootcount(uint16_t* val);
+int imx93_write_bootcount(uint16_t val);
+


### PR DESCRIPTION
Straightforward implementation of bootcount support for the IMX93 platform.

The only difference with the IMX8M platform is that the non-volatile register used to store the bootcount is **BBNSM GPR0** (memory mapped at address `0x44440300`) and not **SNVS_LP GPR0** (memory mapped at address `0x30370090`).

Please note that there is no *explicit* bootcount support for the IMX93 platform in U-Boot yet (i.e. no *defconfig* file defining `SYS_BOOTCOUNT_ADDR`), so the memory address of the register has been taken from the SoC's reference manual.

Finally, code has been tested on an i.MX93 powered SoM by Variscite (product name: [VAR-SOM-MX93](https://www.variscite.it/product/system-on-module-som/cortex-a55/var-som-mx93-nxp-i-mx-93/)).